### PR TITLE
Adopt Material Design 3 with dynamic color theming

### DIFF
--- a/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
@@ -20,7 +20,7 @@ import com.example.learningenglishapplication.R;
 import com.example.learningenglishapplication.Vocabulary.VocabularyListActivity;
 import com.example.learningenglishapplication.category.CategoryAdapter;
 import com.example.learningenglishapplication.category.CategoryManagementActivity;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.navigation.NavigationBarView;
 
 import java.util.Random;
 
@@ -32,7 +32,7 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
     private UserDataHelper userDataHelper;
     private long currentUserId;
     private String currentUserEmail;
-    private BottomNavigationView bottomNavigation;
+    private NavigationBarView bottomNavigation;
     private TextView quoteTextView;
     private TextView tvLoiChao, tvTenNguoiDung;
     private ImageView ivAvatar;

--- a/app/src/main/java/com/example/learningenglishapplication/Home/MyApplication.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Home/MyApplication.java
@@ -2,10 +2,14 @@ package com.example.learningenglishapplication.Home;
 
 import android.app.Application;
 
+import com.google.android.material.color.DynamicColors;
+
 // Lớp này sẽ chạy đầu tiên khi ứng dụng khởi động
 public class MyApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        // Enable dynamic color on supported devices
+        DynamicColors.applyToActivitiesIfAvailable(this);
     }
 }

--- a/app/src/main/java/com/example/learningenglishapplication/Searching/SearchActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Searching/SearchActivity.java
@@ -6,7 +6,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.appbar.MaterialToolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -31,7 +31,7 @@ public class SearchActivity extends AppCompatActivity {
         setContentView(R.layout.activity_search_export);
 
         // --- Thiết lập Toolbar ---
-        Toolbar toolbar = findViewById(R.id.toolbar_search);
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_search);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setTitle("Tìm kiếm Từ vựng");

--- a/app/src/main/java/com/example/learningenglishapplication/Vocabulary/AddEditVocabularyActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Vocabulary/AddEditVocabularyActivity.java
@@ -10,7 +10,7 @@ import android.widget.ImageButton;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.appbar.MaterialToolbar;
 
 import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
 import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper;
@@ -48,7 +48,7 @@ public class AddEditVocabularyActivity extends AppCompatActivity {
         btnSave = findViewById(R.id.btn_save_vocabulary);
 
         // Cài đặt Toolbar
-        Toolbar toolbar = findViewById(R.id.toolbar_add_edit_vocabulary);
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_add_edit_vocabulary);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyDetailActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyDetailActivity.java
@@ -7,7 +7,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.appbar.MaterialToolbar;
 
 import com.example.learningenglishapplication.Data.DatabaseHelper;
 import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper; // SỬA: Sử dụng VocabularyDataHelper
@@ -26,7 +26,7 @@ public class VocabularyDetailActivity extends AppCompatActivity {
         setContentView(R.layout.activity_vocabulary_detail);
 
         // Ánh xạ và thiết lập Toolbar
-        Toolbar toolbar = findViewById(R.id.toolbar_detail);
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_detail);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyListActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyListActivity.java
@@ -21,7 +21,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
-import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.appbar.MaterialToolbar;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -72,7 +72,7 @@ public class VocabularyListActivity extends AppCompatActivity implements Vocabul
             return;
         }
 
-        Toolbar toolbar = findViewById(R.id.toolbar_vocabulary_list);
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_vocabulary_list);
         setSupportActionBar(toolbar);
 
         if (getSupportActionBar() != null) {

--- a/app/src/main/java/com/example/learningenglishapplication/category/CategoryManagementActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/category/CategoryManagementActivity.java
@@ -6,7 +6,7 @@ import android.database.Cursor;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
-import androidx.appcompat.widget.Toolbar;
+import com.google.android.material.appbar.MaterialToolbar;
 import android.view.MenuItem;
 import android.view.Menu;
 import androidx.appcompat.widget.SearchView;
@@ -29,7 +29,7 @@ public class CategoryManagementActivity extends AppCompatActivity implements Cat
     private CategoryDataHelper categoryHelper;
     private FloatingActionButton fabAddCategory;
     private long currentUserId;
-    private Toolbar toolbar;
+    private MaterialToolbar toolbar;
 
 
     @Override

--- a/app/src/main/res/color/nav_item_color.xml
+++ b/app/src/main/res/color/nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="?attr/colorPrimary"/>
+    <item android:color="?attr/colorOnSurfaceVariant"/>
+</selector>

--- a/app/src/main/res/layout/activity_achievements.xml
+++ b/app/src/main/res/layout/activity_achievements.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="#FFFFFF"
-    android:padding="16dp">
+    android:padding="@dimen/spacing_medium">
 
     <TextView
         android:layout_width="match_parent"
@@ -13,7 +13,7 @@
         android:textSize="20sp"
         android:textStyle="bold"
         android:gravity="center"
-        android:layout_marginBottom="16dp" />
+        android:layout_marginBottom="@dimen/spacing_medium" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_achievements"

--- a/app/src/main/res/layout/activity_add_edit_category.xml
+++ b/app/src/main/res/layout/activity_add_edit_category.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp"
+    android:padding="@dimen/spacing_medium"
     android:background="@color/background_color">
 
     <TextView
@@ -17,7 +17,7 @@
         android:id="@+id/et_category_name"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/spacing_small"
         android:hint="Ví dụ: Động từ bất quy tắc"
         android:inputType="text"/>
 
@@ -25,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Mô tả"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="@dimen/spacing_medium"
         android:textColor="@color/text_color_primary"
         android:textSize="16sp"/>
 
@@ -33,7 +33,7 @@
         android:id="@+id/et_category_description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/spacing_small"
         android:hint="Mô tả ngắn gọn về thể loại"
         android:inputType="textMultiLine"
         android:minLines="3"/>
@@ -42,8 +42,8 @@
         android:id="@+id/btn_save_category"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:text="Lưu"
-        android:backgroundTint="@color/colorPrimary"
+        android:backgroundTint="?attr/colorPrimary"
         android:textColor="@color/white"/>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_add_edit_vocabulary.xml
+++ b/app/src/main/res/layout/activity_add_edit_vocabulary.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical"
     android:background="@color/background_color">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_add_edit_vocabulary"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
@@ -16,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:padding="16dp">
+        android:padding="@dimen/spacing_medium">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -27,7 +27,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Từ mới"
-                style="@style/TextAppearance.AppCompat.Title" />
+                style="@style/TextAppearance.Material3.TitleMedium" />
 
             <EditText
                 android:id="@+id/et_word"
@@ -39,8 +39,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Phiên âm"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_marginTop="16dp" />
+                style="@style/TextAppearance.Material3.TitleMedium"
+                android:layout_marginTop="@dimen/spacing_medium" />
 
             <EditText
                 android:id="@+id/et_pronunciation"
@@ -52,8 +52,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Nghĩa của từ"
-                style="@style/TextAppearance.AppCompat.Title"
-                android:layout_marginTop="16dp" />
+                style="@style/TextAppearance.Material3.TitleMedium"
+                android:layout_marginTop="@dimen/spacing_medium" />
 
             <EditText
                 android:id="@+id/et_meaning"
@@ -68,8 +68,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Lưu Từ"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp" />
+        android:layout_marginStart="@dimen/spacing_medium"
+        android:layout_marginEnd="@dimen/spacing_medium"
+        android:layout_marginBottom="@dimen/spacing_medium" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_category_management.xml
+++ b/app/src/main/res/layout/activity_category_management.xml
@@ -8,15 +8,13 @@
     android:background="@color/background_color"
     tools:context=".category.CategoryManagementActivity">
 
-    <!-- THAY THẾ THANH TIÊU ĐỀ CŨ BẰNG TOOLBAR NÀY -->
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_category"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
+        android:background="?attr/colorPrimary"
         app:title="Thể Loại Từ Vựng"
-        app:titleTextColor="@color/white"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+        app:titleTextColor="@color/white"/>
 
     <!-- Danh sách thể loại (Giữ nguyên) -->
     <androidx.recyclerview.widget.RecyclerView
@@ -24,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:padding="8dp"/>
+        android:padding="@dimen/spacing_small"/>
 
     <!-- Nút thêm thể loại mới (Giữ nguyên) -->
     <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -32,8 +30,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:layout_margin="16dp"
+        android:layout_margin="@dimen/spacing_medium"
         android:src="@android:drawable/ic_input_add"
-        app:backgroundTint="@color/colorAccent"/>
+        app:backgroundTint="?attr/colorSecondary"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_flashcard.xml
+++ b/app/src/main/res/layout/activity_flashcard.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp"
+    android:padding="@dimen/spacing_medium"
     android:background="@color/background_color">
 
     <LinearLayout
@@ -59,7 +59,7 @@
                     android:text="/pronunciation/"
                     android:textSize="20sp"
                     android:textColor="@color/text_color_secondary"
-                    android:layout_marginTop="8dp" />
+                    android:layout_marginTop="@dimen/spacing_small" />
             </LinearLayout>
 
             <LinearLayout
@@ -67,7 +67,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:layout_gravity="top|end"
-                android:layout_margin="16dp">
+                android:layout_margin="@dimen/spacing_medium">
 
                 <ImageView
                     android:id="@+id/iv_edit_front"
@@ -83,7 +83,7 @@
                     android:layout_height="32dp"
                     android:src="@drawable/ic_favorite_border"
                     android:padding="4dp"
-                    android:layout_marginStart="8dp"
+                    android:layout_marginStart="@dimen/spacing_small"
                     android:contentDescription="Yêu thích"/>
             </LinearLayout>
         </FrameLayout>
@@ -116,7 +116,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:layout_gravity="top|end"
-                android:layout_margin="16dp">
+                android:layout_margin="@dimen/spacing_medium">
 
                 <ImageView
                     android:id="@+id/iv_edit_back"
@@ -132,7 +132,7 @@
                     android:layout_height="32dp"
                     android:src="@drawable/ic_favorite_border"
                     android:padding="4dp"
-                    android:layout_marginStart="8dp"
+                    android:layout_marginStart="@dimen/spacing_small"
                     android:contentDescription="Yêu thích"/>
             </LinearLayout>
         </FrameLayout>
@@ -142,7 +142,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:gravity="center">
 
         <Button
@@ -151,7 +151,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Trước"
-            android:layout_marginEnd="8dp" />
+            android:layout_marginEnd="@dimen/spacing_small" />
 
         <Button
             android:id="@+id/btn_next_card"
@@ -159,7 +159,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Tiếp"
-            android:layout_marginStart="8dp" />
+            android:layout_marginStart="@dimen/spacing_small" />
 
         <Button
             android:id="@+id/btn_complete"
@@ -167,6 +167,6 @@
             android:layout_height="wrap_content"
             android:text="Hoàn thành"
             android:visibility="gone"
-            android:layout_marginTop="16dp" />
+            android:layout_marginTop="@dimen/spacing_medium" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -17,7 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="@dimen/spacing_medium">
 
             <!-- Search + Avatar -->
             <!-- Lời chào + Avatar -->
@@ -25,7 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:padding="16dp"
+                android:padding="@dimen/spacing_medium"
                 android:gravity="center_vertical"
                 android:background="@drawable/bg_nen_mau_xanh">
 
@@ -74,7 +74,7 @@
                 android:text="Chuỗi ngày học"
                 android:textStyle="bold"
                 android:textSize="16sp"
-                android:layout_marginBottom="8dp" />
+                android:layout_marginBottom="@dimen/spacing_small" />
 
             <TextView
                 android:id="@+id/thong_bao_chuoi"
@@ -91,7 +91,7 @@
                 android:id="@+id/imageButton2"
                 android:layout_width="match_parent"
                 android:layout_height="150dp"
-                android:layout_marginBottom="16dp"
+                android:layout_marginBottom="@dimen/spacing_medium"
                 android:background="@android:color/transparent"
                 android:scaleType="centerInside"
                 app:srcCompat="@drawable/streak"
@@ -107,9 +107,9 @@
                 android:textStyle="italic"
                 android:textSize="18sp"
                 android:background="@drawable/bg_nen_mau_xanh"
-                android:padding="16dp"
+                android:padding="@dimen/spacing_medium"
                 android:gravity="center"
-                android:layout_marginBottom="16dp"
+                android:layout_marginBottom="@dimen/spacing_medium"
                 android:clickable="true"
                 android:focusable="true" />
 
@@ -120,24 +120,26 @@
                 android:text="Học Phần"
                 android:textStyle="bold"
                 android:textSize="16sp"
-                android:layout_marginBottom="8dp" />
+                android:layout_marginBottom="@dimen/spacing_small" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_home_categories"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="24dp"
+                android:layout_marginBottom="@dimen/spacing_large"
                 android:nestedScrollingEnabled="false"
                 tools:listitem="@layout/item_category" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
+    <com.google.android.material.navigation.NavigationBarView
         android:id="@+id/bottom_navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="?android:attr/windowBackground"
         app:menu="@menu/bottom_nav_menu"
+        app:itemIconTint="@color/nav_item_color"
+        app:itemTextColor="@color/nav_item_color"
         app:labelVisibilityMode="labeled" />
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:gravity="center"
-    android:padding="24dp"
+    android:padding="@dimen/spacing_large"
     android:background="@color/background_color"
     tools:context=".Auth.LoginActivity">
 
@@ -15,14 +15,14 @@
         android:text="Chào mừng trở lại!"
         android:textSize="28sp"
         android:textStyle="bold"
-        android:textColor="@color/colorPrimary"/>
+        android:textColor="?attr/colorPrimary"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Đăng nhập để tiếp tục"
         android:textSize="16sp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/spacing_small"
         android:textColor="@color/text_color_secondary"/>
 
     <!-- Form đăng nhập -->
@@ -41,7 +41,7 @@
             android:id="@+id/et_login_email"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/spacing_small"
             android:hint="nhapemail@gmail.com"
             android:inputType="textEmailAddress"
             android:background="@drawable/item_background"
@@ -51,14 +51,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Mật khẩu"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@dimen/spacing_medium"
             android:textColor="@color/text_color_primary"/>
 
         <EditText
             android:id="@+id/et_login_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/spacing_small"
             android:hint="Nhập mật khẩu của bạn"
             android:inputType="textPassword"
             android:background="@drawable/item_background"
@@ -69,10 +69,10 @@
         android:id="@+id/btn_login"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:text="Đăng Nhập"
         android:padding="12dp"
-        android:backgroundTint="@color/colorPrimary"
+        android:backgroundTint="?attr/colorPrimary"
         android:textColor="@color/white"/>
 
     <!-- Link sang màn hình đăng ký -->
@@ -80,7 +80,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="24dp">
+        android:layout_marginTop="@dimen/spacing_large">
 
         <TextView
             android:layout_width="wrap_content"
@@ -94,6 +94,6 @@
             android:layout_height="wrap_content"
             android:text="Đăng ký ngay"
             android:textStyle="bold"
-            android:textColor="@color/colorAccent"/>
+            android:textColor="?attr/colorSecondary"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_profile_settings.xml
+++ b/app/src/main/res/layout/activity_profile_settings.xml
@@ -13,8 +13,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Cá Nhân"
-        android:padding="16dp"
-        android:background="@color/colorPrimary"
+        android:padding="@dimen/spacing_medium"
+        android:background="?attr/colorPrimary"
         android:textColor="@color/white"
         android:textSize="20sp"
         android:textStyle="bold"
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="@dimen/spacing_medium">
 
             <!-- Thống kê nhanh -->
             <TextView
@@ -42,8 +42,8 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:background="@drawable/item_background"
-                android:layout_marginTop="8dp"
-                android:padding="16dp">
+                android:layout_marginTop="@dimen/spacing_small"
+                android:padding="@dimen/spacing_medium">
                 <TextView
                     android:id="@+id/tv_stats_summary"
                     android:layout_width="wrap_content"
@@ -55,7 +55,7 @@
                     android:id="@+id/bar_chart_stats"
                     android:layout_width="match_parent"
                     android:layout_height="200dp"
-                    android:layout_marginTop="16dp"/>
+                    android:layout_marginTop="@dimen/spacing_medium"/>
             </LinearLayout>
 
 
@@ -64,14 +64,14 @@
                 style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="@dimen/spacing_large"
                 android:text="Cài đặt học tập"
                 android:textColor="@color/text_color_primary"/>
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
                 <TextView
                     android:layout_width="0dp"
@@ -91,7 +91,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
                 <TextView
                     android:layout_width="0dp"
@@ -113,14 +113,14 @@
                 style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="@dimen/spacing_large"
                 android:text="Cài đặt ứng dụng"
                 android:textColor="@color/text_color_primary"/>
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
                 <TextView
                     android:layout_width="0dp"
@@ -145,7 +145,7 @@
                 android:text="Đăng xuất"
                 android:backgroundTint="@android:color/holo_red_light"
                 android:textColor="@color/white"
-                android:layout_marginTop="32dp"/>
+                android:layout_marginTop="@dimen/spacing_extra_large"/>
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_quiz.xml
+++ b/app/src/main/res/layout/activity_quiz.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:background="@color/background_color"
-    android:padding="16dp"
+    android:padding="@dimen/spacing_medium"
     tools:context=".Quiz.QuizActivity">
 
     <!-- Thanh tiến trình và thông tin -->
@@ -29,15 +29,15 @@
             android:layout_weight="1"
             android:max="100"
             android:progress="25"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"/>
+            android:layout_marginStart="@dimen/spacing_medium"
+            android:layout_marginEnd="@dimen/spacing_medium"/>
         <TextView
             android:id="@+id/tv_score"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="16sp"
             android:textStyle="bold"
-            android:textColor="@color/colorAccent"
+            android:textColor="?attr/colorSecondary"
             tools:text="Điểm: 4"/>
     </LinearLayout>
 
@@ -45,10 +45,10 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="180dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:background="@drawable/item_background"
         android:gravity="center"
-        android:padding="16dp">
+        android:padding="@dimen/spacing_medium">
 
         <TextView
             android:id="@+id/tv_question_word"
@@ -66,26 +66,26 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="@dimen/spacing_large"
         android:gravity="center">
 
         <Button
             android:id="@+id/btn_answer_1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="@dimen/spacing_small"
             tools:text="Hiện tượng"/>
         <Button
             android:id="@+id/btn_answer_2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="@dimen/spacing_small"
             tools:text="Cơ hội"/>
         <Button
             android:id="@+id/btn_answer_3"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="@dimen/spacing_small"
             tools:text="Chính phủ"/>
         <Button
             android:id="@+id/btn_answer_4"

--- a/app/src/main/res/layout/activity_quiz_result.xml
+++ b/app/src/main/res/layout/activity_quiz_result.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:gravity="center"
-    android:padding="16dp"
+    android:padding="@dimen/spacing_medium"
     android:background="@color/background_color"
     tools:context=".Quiz.QuizResultActivity">
 
@@ -15,14 +15,14 @@
         android:text="Hoàn Thành!"
         android:textSize="32sp"
         android:textStyle="bold"
-        android:textColor="@color/colorPrimary"/>
+        android:textColor="?attr/colorPrimary"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Đây là kết quả của bạn"
         android:textSize="18sp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/spacing_small"
         android:textColor="@color/text_color_secondary"/>
 
     <!-- Khung kết quả -->
@@ -30,8 +30,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="24dp"
-        android:layout_marginTop="32dp"
+        android:padding="@dimen/spacing_large"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:background="@drawable/item_background">
 
         <TextView
@@ -49,15 +49,15 @@
             android:textStyle="bold"
             android:textColor="@color/text_color_primary"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/spacing_small"
             tools:text="18/20"/>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/divider_color"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"/>
+            android:layout_marginTop="@dimen/spacing_medium"
+            android:layout_marginBottom="@dimen/spacing_medium"/>
 
         <!-- Chi tiết -->
         <LinearLayout
@@ -82,7 +82,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:layout_marginTop="8dp">
+            android:layout_marginTop="@dimen/spacing_small">
             <TextView
                 android:layout_width="0dp"
                 android:layout_weight="1"
@@ -105,7 +105,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_marginTop="32dp">
+        android:layout_marginTop="@dimen/spacing_extra_large">
 
         <Button
             android:id="@+id/btn_retry_quiz"
@@ -118,6 +118,6 @@
             android:layout_height="wrap_content"
             android:text="Về màn hình chính"
             style="?attr/materialButtonOutlinedStyle"
-            android:layout_marginTop="8dp"/>
+            android:layout_marginTop="@dimen/spacing_small"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_setup.xml
+++ b/app/src/main/res/layout/activity_quiz_setup.xml
@@ -12,8 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Tạo Bài Kiểm Tra"
-        android:padding="16dp"
-        android:background="@color/colorPrimary"
+        android:padding="@dimen/spacing_medium"
+        android:background="?attr/colorPrimary"
         android:textColor="@color/white"
         android:textSize="20sp"
         android:textStyle="bold"
@@ -23,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="@dimen/spacing_medium">
 
         <!-- Chọn thể loại -->
         <TextView
@@ -36,14 +36,14 @@
             android:id="@+id/spinner_quiz_category"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:layout_marginTop="8dp"/>
+            android:layout_marginTop="@dimen/spacing_small"/>
 
         <!-- Số lượng câu hỏi -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Số lượng câu hỏi"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@dimen/spacing_medium"
             android:textColor="@color/text_color_primary"
             android:textSize="16sp"/>
         <EditText
@@ -51,7 +51,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="number"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="@dimen/spacing_small"
             android:hint="Ví dụ: 20"/>
 
         <!-- Dạng bài tập -->
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Dạng bài tập"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@dimen/spacing_medium"
             android:textColor="@color/text_color_primary"
             android:textSize="16sp"/>
         <RadioGroup
@@ -67,7 +67,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_marginTop="8dp">
+            android:layout_marginTop="@dimen/spacing_small">
             <RadioButton android:id="@+id/rb_multiple_choice" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Trắc nghiệm (chọn nghĩa)" android:checked="true"/>
             <RadioButton android:id="@+id/rb_fill_in_blank" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Điền từ (chọn từ)"/>
         </RadioGroup>
@@ -83,9 +83,9 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:text="Bắt đầu"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="@dimen/spacing_extra_large"
             android:padding="12dp"
-            android:backgroundTint="@color/colorAccent"
+            android:backgroundTint="?attr/colorSecondary"
             android:textColor="@color/white"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:gravity="center"
-    android:padding="24dp"
+    android:padding="@dimen/spacing_large"
     android:background="@color/background_color"
     tools:context=".Auth.RegisterActivity">
 
@@ -15,21 +15,21 @@
         android:text="Tạo tài khoản mới"
         android:textSize="28sp"
         android:textStyle="bold"
-        android:textColor="@color/colorPrimary"/>
+        android:textColor="?attr/colorPrimary"/>
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Bắt đầu hành trình học từ vựng của bạn"
         android:textSize="16sp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/spacing_small"
         android:textColor="@color/text_color_secondary"/>
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:layout_marginTop="32dp">
+        android:layout_marginTop="@dimen/spacing_extra_large">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -46,7 +46,7 @@
                 android:id="@+id/et_register_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:hint="nhapemail@gmail.com"
                 android:inputType="textEmailAddress"
                 android:background="@drawable/item_background"
@@ -57,13 +57,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Biệt danh"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:textColor="@color/text_color_primary"/>
             <EditText
                 android:id="@+id/et_register_nickname"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:hint="Nhập biệt danh"
                 android:inputType="textPersonName"
                 android:background="@drawable/item_background"
@@ -74,13 +74,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Mật khẩu"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:textColor="@color/text_color_primary"/>
             <EditText
                 android:id="@+id/et_register_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:hint="Tối thiểu 6 ký tự"
                 android:inputType="textPassword"
                 android:background="@drawable/item_background"
@@ -91,13 +91,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Xác nhận mật khẩu"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:textColor="@color/text_color_primary"/>
             <EditText
                 android:id="@+id/et_register_confirm_password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:hint="Nhập lại mật khẩu"
                 android:inputType="textPassword"
                 android:background="@drawable/item_background"
@@ -110,17 +110,17 @@
         android:id="@+id/btn_register"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="@dimen/spacing_large"
         android:text="Đăng Ký"
         android:padding="12dp"
-        android:backgroundTint="@color/colorPrimary"
+        android:backgroundTint="?attr/colorPrimary"
         android:textColor="@color/white"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="24dp">
+        android:layout_marginTop="@dimen/spacing_large">
 
         <TextView
             android:layout_width="wrap_content"
@@ -134,7 +134,7 @@
             android:layout_height="wrap_content"
             android:text="Đăng nhập"
             android:textStyle="bold"
-            android:textColor="@color/colorAccent"/>
+            android:textColor="?attr/colorSecondary"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_search_export.xml
+++ b/app/src/main/res/layout/activity_search_export.xml
@@ -8,14 +8,12 @@
     android:background="@color/background_color"
     tools:context=".Searching.SearchActivity">
 
-    <!-- THÊM TOOLBAR VÀO ĐÂY VÀ THAY THẾ TEXTVIEW TIÊU ĐỀ CŨ -->
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_search"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
-        app:titleTextColor="@color/white"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@color/white"/>
 
     <!-- Phần còn lại của layout giữ nguyên -->
     <ScrollView
@@ -27,7 +25,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="@dimen/spacing_medium">
 
             <!-- Khung tìm kiếm -->
             <TextView
@@ -41,7 +39,7 @@
                 android:id="@+id/et_search_keyword"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:hint="Nhập từ hoặc nghĩa..."/>
 
             <!-- Bỏ qua các bộ lọc khác để đơn giản hóa -->
@@ -51,9 +49,9 @@
                 android:id="@+id/btn_search"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="@dimen/spacing_medium"
                 android:text="Tìm Kiếm"
-                android:backgroundTint="@color/colorPrimary"
+                android:backgroundTint="?attr/colorPrimary"
                 android:textColor="@color/white"/>
 
             <!-- Vạch ngăn cách -->
@@ -61,8 +59,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:background="@color/divider_color"
-                android:layout_marginTop="24dp"
-                android:layout_marginBottom="16dp"/>
+                android:layout_marginTop="@dimen/spacing_large"
+                android:layout_marginBottom="@dimen/spacing_medium"/>
 
             <!-- Khu vực kết quả -->
             <TextView
@@ -77,7 +75,7 @@
                 android:id="@+id/rv_search_results"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="@dimen/spacing_small"
                 tools:listitem="@layout/item_vocabulary"
                 tools:itemCount="3"/>
         </LinearLayout>

--- a/app/src/main/res/layout/activity_vocabulary_detail.xml
+++ b/app/src/main/res/layout/activity_vocabulary_detail.xml
@@ -7,19 +7,18 @@
     android:orientation="vertical"
     tools:context=".Vocabulary.VocabularyDetailActivity">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_detail"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
-        app:titleTextColor="@color/white"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@color/white" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:padding="16dp"
+        android:padding="@dimen/spacing_medium"
         android:gravity="center_horizontal">
 
         <TextView
@@ -30,7 +29,7 @@
             android:textSize="32sp"
             android:textStyle="bold"
             android:textColor="@color/black"
-            android:layout_marginTop="32dp"/>
+            android:layout_marginTop="@dimen/spacing_extra_large"/>
 
         <TextView
             android:id="@+id/tv_detail_pronunciation"
@@ -39,7 +38,7 @@
             android:text="[prəˌnʌnsiˈeɪʃən]"
             android:textSize="20sp"
             android:textColor="@android:color/darker_gray"
-            android:layout_marginTop="8dp"/>
+            android:layout_marginTop="@dimen/spacing_small"/>
 
         <TextView
             android:id="@+id/tv_detail_meaning"
@@ -48,7 +47,7 @@
             android:text="Nghĩa của từ vựng"
             android:textSize="24sp"
             android:textColor="@color/black"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="@dimen/spacing_medium"
             android:gravity="center"/>
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_vocabulary_list.xml
+++ b/app/src/main/res/layout/activity_vocabulary_list.xml
@@ -8,30 +8,29 @@
     android:background="@color/background_color"
     tools:context=".Vocabulary.VocabularyListActivity">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_vocabulary_list"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
-        app:titleTextColor="@color/white"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@color/white">
 
         <ImageView
             android:id="@+id/btn_filter"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="@dimen/spacing_medium"
             android:src="@drawable/ic_filter_list"
             android:contentDescription="Lọc danh sách" />
 
-    </androidx.appcompat.widget.Toolbar>
+    </com.google.android.material.appbar.MaterialToolbar>
 
     <TextView
         android:id="@+id/tv_vocabulary_count"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp"
+        android:padding="@dimen/spacing_small"
         android:background="@color/divider_color"
         android:textColor="@color/text_color_primary"
         android:textSize="16sp"
@@ -43,9 +42,9 @@
         android:id="@+id/btn_start_flashcard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
+        android:layout_margin="@dimen/spacing_medium"
         android:text="Ôn Tập Flashcard"
-        android:backgroundTint="@color/colorAccent"
+        android:backgroundTint="?attr/colorSecondary"
         android:textColor="@color/white" />
 
     <TextView
@@ -54,7 +53,7 @@
         android:layout_height="wrap_content"
         android:text="Hãy thêm từ mới"
         android:layout_gravity="center"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
         android:textSize="18sp"
         android:textColor="@android:color/black"
         android:visibility="gone" />
@@ -64,15 +63,15 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:padding="8dp" />
+        android:padding="@dimen/spacing_small" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_vocabulary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:layout_margin="16dp"
+        android:layout_margin="@dimen/spacing_medium"
         android:src="@android:drawable/ic_input_add"
-        app:backgroundTint="@color/colorAccent" />
+        app:backgroundTint="?attr/colorSecondary" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_achievement.xml
+++ b/app/src/main/res/layout/item_achievement.xml
@@ -1,42 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:padding="12dp"
-    android:background="@drawable/bg_nen_mau_xanh"
-    android:layout_marginBottom="12dp">
-
-    <ImageView
-        android:id="@+id/img_badge"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
-        android:src="@drawable/ic_medal"
-        android:contentDescription="Huy hiệu"
-        android:layout_marginEnd="12dp" />
+    android:layout_marginBottom="@dimen/spacing_small"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp"
+    android:background="@drawable/bg_nen_mau_xanh">
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:padding="12dp">
 
-        <TextView
-            android:id="@+id/tv_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Tiêu đề thành tựu"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:textColor="@android:color/black" />
+        <ImageView
+            android:id="@+id/img_badge"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:src="@drawable/ic_medal"
+            android:contentDescription="Huy hiệu"
+            android:layout_marginEnd="@dimen/spacing_small" />
 
-        <TextView
-            android:id="@+id/tv_description"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Mô tả ngắn gọn về thành tựu"
-            android:textSize="14sp"
-            android:textColor="@android:color/darker_gray" />
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tv_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Tiêu đề thành tựu"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:textColor="@android:color/black" />
+
+            <TextView
+                android:id="@+id/tv_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Mô tả ngắn gọn về thành tựu"
+                android:textSize="14sp"
+                android:textColor="@android:color/darker_gray" />
+        </LinearLayout>
     </LinearLayout>
-
-</LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -1,54 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp"
-    android:layout_margin="8dp"
-    android:background="@drawable/item_background"> <!-- Tạo một background bo góc -->
+    android:layout_margin="@dimen/spacing_small"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="8dp">
 
-    <TextView
-        android:id="@+id/tv_category_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Tên Thể Loại"
-        android:textSize="18sp"
-        android:textColor="@color/text_color_primary"
-        android:textStyle="bold"/>
-    <TextView
-        android:id="@+id/description_vocabulary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Miêu tả"
-        android:textSize="14sp"
-        android:textColor="@color/text_color_secondary"
-        android:layout_marginTop="4dp"/>
-    <TextView
-        android:id="@+id/tv_word_count"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Số từ: 20"
-        android:textSize="14sp"
-        android:textColor="@color/text_color_secondary"
-        android:layout_marginTop="4dp"/>
-    <!-- Thanh tiến độ học từ -->
-    <ProgressBar
-        android:id="@+id/progress_category"
-        style="?android:attr/progressBarStyleHorizontal"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="10dp"
-        android:layout_marginTop="6dp"
-        android:max="100" />
-
-    <!-- Nhãn phần trăm (tuỳ chọn) -->
-    <TextView
-        android:id="@+id/tv_progress_percent"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="0%"
-        android:textSize="12sp"
-        android:layout_marginTop="4dp"
-        android:textColor="@color/text_color_secondary"/>
+        android:orientation="vertical"
+        android:padding="@dimen/spacing_medium">
 
+        <TextView
+            android:id="@+id/tv_category_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Tên Thể Loại"
+            android:textSize="18sp"
+            android:textColor="@color/text_color_primary"
+            android:textStyle="bold"/>
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/description_vocabulary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Miêu tả"
+            android:textSize="14sp"
+            android:textColor="@color/text_color_secondary"
+            android:layout_marginTop="@dimen/spacing_small"/>
+
+        <TextView
+            android:id="@+id/tv_word_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Số từ: 20"
+            android:textSize="14sp"
+            android:textColor="@color/text_color_secondary"
+            android:layout_marginTop="@dimen/spacing_small"/>
+
+        <ProgressBar
+            android:id="@+id/progress_category"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="10dp"
+            android:layout_marginTop="6dp"
+            android:max="100" />
+
+        <TextView
+            android:id="@+id/tv_progress_percent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0%"
+            android:textSize="12sp"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:textColor="@color/text_color_secondary"/>
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_vocabulary.xml
+++ b/app/src/main/res/layout/item_vocabulary.xml
@@ -1,41 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:padding="16dp"
-    android:layout_margin="8dp"
-    android:gravity="center_vertical"
-    android:background="@drawable/item_background">
+    android:layout_margin="@dimen/spacing_small"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="8dp">
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:padding="@dimen/spacing_medium"
+        android:gravity="center_vertical">
 
-        <TextView
-            android:id="@+id/tv_word"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Word"
-            android:textSize="18sp"
-            android:textColor="@color/text_color_primary"
-            android:textStyle="bold"/>
+            android:layout_weight="1"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/tv_meaning"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Meaning"
-            android:textSize="14sp"
-            android:textColor="@color/text_color_secondary"
-            android:layout_marginTop="4dp"/>
+            <TextView
+                android:id="@+id/tv_word"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Word"
+                android:textSize="18sp"
+                android:textColor="@color/text_color_primary"
+                android:textStyle="bold"/>
+
+            <TextView
+                android:id="@+id/tv_meaning"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Meaning"
+                android:textSize="14sp"
+                android:textColor="@color/text_color_secondary"
+                android:layout_marginTop="@dimen/spacing_small"/>
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/iv_favorite"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_favorite_border" />
     </LinearLayout>
-
-    <ImageView
-        android:id="@+id/iv_favorite"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:src="@drawable/ic_favorite_border" />
-</LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Legacy color references for dark theme -->
+    <color name="colorPrimary">@color/md_theme_dark_primary</color>
+    <color name="colorPrimaryDark">@color/md_theme_dark_primary</color>
+    <color name="colorAccent">@color/md_theme_dark_secondary</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,26 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Base.Theme.LearningEnglishApplication" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your dark theme here. -->
-        <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+    <style name="Theme.LearningEnglishApplication" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/md_theme_dark_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_dark_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_dark_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_dark_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_dark_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_dark_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_dark_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_dark_error</item>
+        <item name="colorOnError">@color/md_theme_dark_onError</item>
+        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
+        <item name="colorSurface">@color/md_theme_dark_surface</item>
+        <item name="colorOnSurface">@color/md_theme_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_dark_onSurfaceVariant</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,20 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
-    <color name="black">#FF000000</color>
-    <color name="white">#FFFFFFFF</color>
-    <color name="gray">#808080</color>
-    <color name="red">#F44336</color>
-    <color name="green">#4CAF50</color>
+    <!-- Material 3 color scheme -->
+    <color name="md_theme_light_primary">#6750A4</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#EADDFF</color>
+    <color name="md_theme_light_onPrimaryContainer">#21005D</color>
+    <color name="md_theme_light_secondary">#625B71</color>
+    <color name="md_theme_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_light_secondaryContainer">#E8DEF8</color>
+    <color name="md_theme_light_onSecondaryContainer">#1D192B</color>
+    <color name="md_theme_light_tertiary">#7D5260</color>
+    <color name="md_theme_light_onTertiary">#FFFFFF</color>
+    <color name="md_theme_light_tertiaryContainer">#FFD8E4</color>
+    <color name="md_theme_light_onTertiaryContainer">#31111D</color>
+    <color name="md_theme_light_error">#B3261E</color>
+    <color name="md_theme_light_onError">#FFFFFF</color>
+    <color name="md_theme_light_errorContainer">#F9DEDC</color>
+    <color name="md_theme_light_onErrorContainer">#410E0B</color>
+    <color name="md_theme_light_background">#FFFBFE</color>
+    <color name="md_theme_light_onBackground">#1C1B1F</color>
+    <color name="md_theme_light_surface">#FFFBFE</color>
+    <color name="md_theme_light_onSurface">#1C1B1F</color>
+    <color name="md_theme_light_surfaceVariant">#E7E0EC</color>
+    <color name="md_theme_light_onSurfaceVariant">#49454F</color>
+    <color name="md_theme_light_outline">#79747E</color>
 
-    <!-- Custom Colors -->
-    <color name="colorPrimary">#6200EE</color>
-    <color name="colorPrimaryDark">#3700B3</color>
-    <color name="colorAccent">#03DAC5</color>
+    <color name="md_theme_dark_primary">#D0BCFF</color>
+    <color name="md_theme_dark_onPrimary">#381E72</color>
+    <color name="md_theme_dark_primaryContainer">#4F378B</color>
+    <color name="md_theme_dark_onPrimaryContainer">#EADDFF</color>
+    <color name="md_theme_dark_secondary">#CCC2DC</color>
+    <color name="md_theme_dark_onSecondary">#332D41</color>
+    <color name="md_theme_dark_secondaryContainer">#4A4458</color>
+    <color name="md_theme_dark_onSecondaryContainer">#E8DEF8</color>
+    <color name="md_theme_dark_tertiary">#EFB8C8</color>
+    <color name="md_theme_dark_onTertiary">#492532</color>
+    <color name="md_theme_dark_tertiaryContainer">#633B48</color>
+    <color name="md_theme_dark_onTertiaryContainer">#FFD8E4</color>
+    <color name="md_theme_dark_error">#F2B8B5</color>
+    <color name="md_theme_dark_onError">#601410</color>
+    <color name="md_theme_dark_errorContainer">#8C1D18</color>
+    <color name="md_theme_dark_onErrorContainer">#F9DEDC</color>
+    <color name="md_theme_dark_background">#1C1B1F</color>
+    <color name="md_theme_dark_onBackground">#E6E1E5</color>
+    <color name="md_theme_dark_surface">#1C1B1F</color>
+    <color name="md_theme_dark_onSurface">#E6E1E5</color>
+    <color name="md_theme_dark_surfaceVariant">#49454F</color>
+    <color name="md_theme_dark_onSurfaceVariant">#CAC4D0</color>
+    <color name="md_theme_dark_outline">#938F99</color>
+
+    <!-- Seed color -->
+    <color name="seed">#6750A4</color>
+
+    <!-- Existing custom colors -->
     <color name="background_color">#F5F5F5</color>
     <color name="text_color_primary">#212121</color>
     <color name="text_color_secondary">#757575</color>
@@ -22,4 +60,9 @@
     <color name="green_learned">#4CAF50</color>
     <color name="red_unlearned">#F44336</color>
     <color name="highlight_border">#FFC107</color>
+
+    <!-- Legacy color references for compatibility -->
+    <color name="colorPrimary">@color/md_theme_light_primary</color>
+    <color name="colorPrimaryDark">@color/md_theme_light_primary</color>
+    <color name="colorAccent">@color/md_theme_light_secondary</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,10 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="app_bar_height">180dp</dimen>
     <dimen name="text_margin">16dp</dimen>
+
+    <!-- Material spacing scale -->
+    <dimen name="spacing_small">8dp</dimen>
+    <dimen name="spacing_medium">16dp</dimen>
+    <dimen name="spacing_large">24dp</dimen>
+    <dimen name="spacing_extra_large">32dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,20 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-    </style>
-
     <!-- Style cho LinearLayout bên trong thẻ chức năng -->
     <style name="FeatureCard">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:orientation">vertical</item>
         <item name="android:gravity">center</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:padding">@dimen/spacing_medium</item>
         <item name="android:clickable">true</item>
         <item name="android:focusable">true</item>
         <item name="android:background">?android:attr/selectableItemBackground</item>
@@ -24,15 +16,15 @@
     <style name="FeatureIcon">
         <item name="android:layout_width">40dp</item>
         <item name="android:layout_height">40dp</item>
-        <item name="android:layout_marginBottom">8dp</item>
-        <item name="android:tint">@color/colorPrimary</item>
+        <item name="android:layout_marginBottom">@dimen/spacing_small</item>
+        <item name="android:tint">?attr/colorPrimary</item>
     </style>
 
     <!-- Style cho Tiêu đề trong thẻ chức năng -->
     <style name="FeatureTitle">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:textColor">@color/text_color_primary</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">14sp</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,21 +1,26 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Base.Theme.LearningEnglishApplication" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
-    </style>
-
-    <style name="Theme.LearningEnglishApplication" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" >?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+    <style name="Theme.LearningEnglishApplication" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_light_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_light_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_light_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_light_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_light_error</item>
+        <item name="colorOnError">@color/md_theme_light_onError</item>
+        <item name="colorErrorContainer">@color/md_theme_light_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/md_theme_light_onErrorContainer</item>
+        <item name="colorSurface">@color/md_theme_light_surface</item>
+        <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- migrate app theme to Material Design 3 and add full color scheme
- enable dynamic colors and replace legacy widgets with Material components
- update layouts to use Material spacing and card components

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1e3b2e4832981c036d8c2a40025