### PR TITLE
Add learning game modes with score tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
         <activity android:name=".Profile.ProfileSettingsActivity" />
         <activity android:name=".Vocabulary.VocabularyDetailActivity" />
         <activity android:name=".Achivements.AchievementsActivity" />
+        <activity android:name=".Game.LearnActivity" />
+        <activity android:name=".Game.MatchActivity" />
+        <activity android:name=".Game.TestActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/learningenglishapplication/Data/DataHelper/VocabularyDataHelper.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Data/DataHelper/VocabularyDataHelper.java
@@ -307,6 +307,43 @@ public class VocabularyDataHelper {
     }
 
     /**
+     * Lấy danh sách từ vựng cho một người dùng.
+     * Nếu favoritesOnly = true thì chỉ lấy các từ được đánh dấu yêu thích.
+     */
+    public List<Vocabulary> getVocabulariesForUser(long userId, boolean favoritesOnly) {
+        List<Vocabulary> vocabularyList = new ArrayList<>();
+        SQLiteDatabase db = dbHelper.getReadableDatabase();
+        String selection = DatabaseHelper.COLUMN_VOCAB_USER_ID + "=?";
+        if (favoritesOnly) {
+            selection += " AND " + DatabaseHelper.COLUMN_VOCAB_IS_FAVORITE + "=1";
+        }
+        Cursor cursor = db.query(DatabaseHelper.TABLE_VOCABULARIES, null, selection,
+                new String[]{String.valueOf(userId)}, null, null, null);
+
+        if (cursor.moveToFirst()) {
+            do {
+                long id = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_ID));
+                String word = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_WORD));
+                String meaning = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_MEANING));
+                String pronunciation = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_PRONUNCIATION));
+                int isFavorite = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_IS_FAVORITE));
+                int learned = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_LEARNED));
+                String dateLearned = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_DATE_LEARNED));
+                String imageUri = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_IMAGE_URI));
+                String audioUri = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_AUDIO_URI));
+                int box = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_BOX));
+                long nextReview = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_NEXT_REVIEW));
+
+                vocabularyList.add(new Vocabulary(id, word, meaning, pronunciation, isFavorite, learned, dateLearned,
+                        imageUri, audioUri, box, nextReview));
+            } while (cursor.moveToNext());
+        }
+        cursor.close();
+        db.close();
+        return vocabularyList;
+    }
+
+    /**
      * Tìm kiếm từ vựng theo từ khóa cho một người dùng.
      * Tìm trong cả cột 'word' và 'meaning'.
      */

--- a/app/src/main/java/com/example/learningenglishapplication/Game/LearnActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Game/LearnActivity.java
@@ -1,0 +1,112 @@
+package com.example.learningenglishapplication.Game;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper;
+import com.example.learningenglishapplication.Data.DatabaseHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Activity luyện tập dạng trắc nghiệm nhiều lựa chọn.
+ */
+public class LearnActivity extends AppCompatActivity implements View.OnClickListener {
+
+    private TextView questionText, scoreText;
+    private Button option1, option2, option3, option4;
+    private List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int currentIndex = 0;
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_learn);
+
+        questionText = findViewById(R.id.question_text);
+        scoreText = findViewById(R.id.score_text);
+        option1 = findViewById(R.id.option1);
+        option2 = findViewById(R.id.option2);
+        option3 = findViewById(R.id.option3);
+        option4 = findViewById(R.id.option4);
+
+        option1.setOnClickListener(this);
+        option2.setOnClickListener(this);
+        option3.setOnClickListener(this);
+        option4.setOnClickListener(this);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        VocabularyDataHelper vocabularyDataHelper = new VocabularyDataHelper(new DatabaseHelper(this));
+        boolean favoritesOnly = getIntent().getBooleanExtra("FAVORITES_ONLY", false);
+        long categoryId = getIntent().getLongExtra("CATEGORY_ID", -1);
+        if (categoryId != -1) {
+            vocabularyList = vocabularyDataHelper.getVocabulariesAsList(categoryId);
+        } else {
+            vocabularyList = vocabularyDataHelper.getVocabulariesForUser(userId, favoritesOnly);
+        }
+        Collections.shuffle(vocabularyList);
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        loadNextQuestion();
+    }
+
+    private void loadNextQuestion() {
+        if (currentIndex >= vocabularyList.size()) {
+            showResult();
+            return;
+        }
+        Vocabulary current = vocabularyList.get(currentIndex);
+        questionText.setText(current.getWord());
+
+        List<String> options = new ArrayList<>();
+        options.add(current.getMeaning());
+        for (int i = 1; i < 4; i++) {
+            Vocabulary v = vocabularyList.get((currentIndex + i) % vocabularyList.size());
+            options.add(v.getMeaning());
+        }
+        Collections.shuffle(options);
+        option1.setText(options.get(0));
+        option2.setText(options.get(1));
+        option3.setText(options.get(2));
+        option4.setText(options.get(3));
+        scoreText.setText(getString(R.string.score_format, score, vocabularyList.size()));
+    }
+
+    @Override
+    public void onClick(View v) {
+        Button b = (Button) v;
+        String selected = b.getText().toString();
+        Vocabulary current = vocabularyList.get(currentIndex);
+        if (selected.equals(current.getMeaning())) {
+            score++;
+            statisticsDataHelper.logWordLearned(userId);
+            Toast.makeText(this, R.string.correct, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, R.string.incorrect, Toast.LENGTH_SHORT).show();
+        }
+        currentIndex++;
+        loadNextQuestion();
+    }
+
+    private void showResult() {
+        String result = getString(R.string.final_score_format, score, vocabularyList.size());
+        scoreText.setText(result);
+    }
+}

--- a/app/src/main/java/com/example/learningenglishapplication/Game/MatchActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Game/MatchActivity.java
@@ -1,0 +1,121 @@
+package com.example.learningenglishapplication.Game;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.DragEvent;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper;
+import com.example.learningenglishapplication.Data.DatabaseHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Activity ghép cặp kéo thả giữa từ và nghĩa.
+ */
+public class MatchActivity extends AppCompatActivity {
+
+    private LinearLayout wordContainer, meaningContainer;
+    private TextView scoreText;
+    private List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_match);
+
+        wordContainer = findViewById(R.id.word_container);
+        meaningContainer = findViewById(R.id.meaning_container);
+        scoreText = findViewById(R.id.score_text);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        VocabularyDataHelper vocabularyDataHelper = new VocabularyDataHelper(new DatabaseHelper(this));
+        boolean favoritesOnly = getIntent().getBooleanExtra("FAVORITES_ONLY", false);
+        long categoryId = getIntent().getLongExtra("CATEGORY_ID", -1);
+        if (categoryId != -1) {
+            vocabularyList = vocabularyDataHelper.getVocabulariesAsList(categoryId);
+        } else {
+            vocabularyList = vocabularyDataHelper.getVocabulariesForUser(userId, favoritesOnly);
+        }
+        Collections.shuffle(vocabularyList);
+        if (vocabularyList.size() > 5) {
+            vocabularyList = vocabularyList.subList(0, 5);
+        }
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        setupViews();
+        updateScore();
+    }
+
+    private void setupViews() {
+        for (Vocabulary v : vocabularyList) {
+            TextView wordView = createTextView(v.getWord());
+            wordView.setTag(v.getMeaning());
+            wordView.setOnLongClickListener(view -> {
+                View.DragShadowBuilder shadow = new View.DragShadowBuilder(view);
+                view.startDragAndDrop(null, shadow, view, 0);
+                return true;
+            });
+            wordContainer.addView(wordView);
+        }
+
+        List<Vocabulary> shuffled = new ArrayList<>(vocabularyList);
+        Collections.shuffle(shuffled);
+        for (Vocabulary v : shuffled) {
+            TextView meaningView = createTextView(v.getMeaning());
+            meaningView.setTag(v.getMeaning());
+            meaningView.setOnDragListener((view, event) -> handleDrag(view, event));
+            meaningContainer.addView(meaningView);
+        }
+    }
+
+    private TextView createTextView(String text) {
+        TextView tv = new TextView(this);
+        tv.setText(text);
+        tv.setPadding(16, 16, 16, 16);
+        tv.setBackgroundResource(R.drawable.bg_nen_mau_xanh);
+        tv.setTextColor(getResources().getColor(android.R.color.black));
+        return tv;
+    }
+
+    private boolean handleDrag(View view, DragEvent event) {
+        if (event.getAction() == DragEvent.ACTION_DROP) {
+            View dragged = (View) event.getLocalState();
+            String from = (String) dragged.getTag();
+            String target = (String) view.getTag();
+            if (from.equals(target)) {
+                dragged.setVisibility(View.INVISIBLE);
+                view.setBackgroundColor(0xFFB2FF59); // Green highlight
+                score++;
+                statisticsDataHelper.logWordLearned(userId);
+                updateScore();
+                if (score == vocabularyList.size()) {
+                    Toast.makeText(this, getString(R.string.final_score_format, score, vocabularyList.size()), Toast.LENGTH_LONG).show();
+                }
+            } else {
+                Toast.makeText(this, R.string.incorrect, Toast.LENGTH_SHORT).show();
+            }
+        }
+        return true;
+    }
+
+    private void updateScore() {
+        scoreText.setText(getString(R.string.score_format, score, vocabularyList.size()));
+    }
+}

--- a/app/src/main/java/com/example/learningenglishapplication/Game/TestActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Game/TestActivity.java
@@ -1,0 +1,95 @@
+package com.example.learningenglishapplication.Game;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper;
+import com.example.learningenglishapplication.Data.DatabaseHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Activity kiểm tra dạng nhập từ.
+ */
+public class TestActivity extends AppCompatActivity {
+
+    private TextView questionText, scoreText;
+    private EditText answerInput;
+    private Button submitButton;
+    private List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int currentIndex = 0;
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test);
+
+        questionText = findViewById(R.id.question_text);
+        scoreText = findViewById(R.id.score_text);
+        answerInput = findViewById(R.id.answer_input);
+        submitButton = findViewById(R.id.submit_button);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        VocabularyDataHelper vocabularyDataHelper = new VocabularyDataHelper(new DatabaseHelper(this));
+        boolean favoritesOnly = getIntent().getBooleanExtra("FAVORITES_ONLY", false);
+        long categoryId = getIntent().getLongExtra("CATEGORY_ID", -1);
+        if (categoryId != -1) {
+            vocabularyList = vocabularyDataHelper.getVocabulariesAsList(categoryId);
+        } else {
+            vocabularyList = vocabularyDataHelper.getVocabulariesForUser(userId, favoritesOnly);
+        }
+        Collections.shuffle(vocabularyList);
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        submitButton.setOnClickListener(v -> checkAnswer());
+        loadNextQuestion();
+    }
+
+    private void loadNextQuestion() {
+        if (currentIndex >= vocabularyList.size()) {
+            showResult();
+            return;
+        }
+        Vocabulary current = vocabularyList.get(currentIndex);
+        questionText.setText(current.getMeaning());
+        answerInput.setText("");
+        scoreText.setText(getString(R.string.score_format, score, vocabularyList.size()));
+    }
+
+    private void checkAnswer() {
+        Vocabulary current = vocabularyList.get(currentIndex);
+        String answer = answerInput.getText().toString().trim();
+        if (answer.equalsIgnoreCase(current.getWord())) {
+            score++;
+            statisticsDataHelper.logWordLearned(userId);
+            Toast.makeText(this, R.string.correct, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, getString(R.string.correct_answer, current.getWord()), Toast.LENGTH_SHORT).show();
+        }
+        currentIndex++;
+        loadNextQuestion();
+    }
+
+    private void showResult() {
+        submitButton.setEnabled(false);
+        scoreText.setText(getString(R.string.final_score_format, score, vocabularyList.size()));
+    }
+}

--- a/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -16,6 +17,9 @@ import com.example.learningenglishapplication.Data.DataHelper.CategoryDataHelper
 import com.example.learningenglishapplication.Data.DataHelper.UserDataHelper;
 import com.example.learningenglishapplication.Profile.ProfileSettingsActivity;
 import com.example.learningenglishapplication.Quiz.QuizSetupActivity;
+import com.example.learningenglishapplication.Game.LearnActivity;
+import com.example.learningenglishapplication.Game.MatchActivity;
+import com.example.learningenglishapplication.Game.TestActivity;
 import com.example.learningenglishapplication.R;
 import com.example.learningenglishapplication.Vocabulary.VocabularyListActivity;
 import com.example.learningenglishapplication.category.CategoryAdapter;
@@ -69,6 +73,9 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
         tvLoiChao = findViewById(R.id.tv_loi_chao);
         tvTenNguoiDung = findViewById(R.id.tv_ten_nguoi_dung);
         ivAvatar = findViewById(R.id.nut_ho_so);
+        Button btnLearn = findViewById(R.id.btn_learn);
+        Button btnMatch = findViewById(R.id.btn_match);
+        Button btnTest = findViewById(R.id.btn_test);
 
         // Lấy thông tin đăng nhập
         SharedPreferences sharedPreferences = getSharedPreferences("user_prefs", MODE_PRIVATE);
@@ -98,6 +105,10 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
             Intent intent = new Intent(HomeActivity.this, AchievementsActivity.class);
             startActivity(intent);
         });
+
+        btnLearn.setOnClickListener(v -> startActivity(new Intent(HomeActivity.this, LearnActivity.class)));
+        btnMatch.setOnClickListener(v -> startActivity(new Intent(HomeActivity.this, MatchActivity.class)));
+        btnTest.setOnClickListener(v -> startActivity(new Intent(HomeActivity.this, TestActivity.class)));
 
         // RecyclerView
         recyclerView = findViewById(R.id.rv_home_categories);

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -113,6 +113,46 @@
                 android:clickable="true"
                 android:focusable="true" />
 
+            <!-- Chế độ luyện tập -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Chế độ học"
+                android:textStyle="bold"
+                android:textSize="16sp"
+                android:layout_marginBottom="@dimen/spacing_small" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center"
+                android:layout_marginBottom="@dimen/spacing_large">
+
+                <Button
+                    android:id="@+id/btn_learn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Learn" />
+
+                <Button
+                    android:id="@+id/btn_match"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="Match" />
+
+                <Button
+                    android:id="@+id/btn_test"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="Test" />
+            </LinearLayout>
+
             <!-- Học phần -->
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_learn.xml
+++ b/app/src/main/res/layout/activity_learn.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="#EDE9FE">
+
+    <TextView
+        android:id="@+id/question_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Question"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp" />
+
+    <Button
+        android:id="@+id/option1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/option2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/option3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/option4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp" />
+
+    <TextView
+        android:id="@+id/score_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Score"
+        android:layout_marginTop="24dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_match.xml
+++ b/app/src/main/res/layout/activity_match.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="#EDE9FE">
+
+    <TextView
+        android:id="@+id/score_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Score"
+        android:layout_marginBottom="16dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:id="@+id/word_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center" />
+
+        <LinearLayout
+            android:id="@+id/meaning_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_test.xml
+++ b/app/src/main/res/layout/activity_test.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="#EDE9FE">
+
+    <TextView
+        android:id="@+id/question_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Meaning"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp" />
+
+    <EditText
+        android:id="@+id/answer_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Type answer" />
+
+    <Button
+        android:id="@+id/submit_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Submit"
+        android:layout_marginTop="12dp" />
+
+    <TextView
+        android:id="@+id/score_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Score"
+        android:layout_marginTop="24dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,10 @@
     <string name="category_progress_label">%1$d/%2$d từ</string>
     <string name="category_progress_percent">%1$d%%</string>
 
+    <string name="score_format">Score: %1$d/%2$d</string>
+    <string name="final_score_format">Completed! Score: %1$d/%2$d</string>
+    <string name="correct">Correct!</string>
+    <string name="incorrect">Incorrect!</string>
+    <string name="correct_answer">Correct answer: %1$s</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- introduce LearnActivity, MatchActivity, and TestActivity with multiple-choice, drag-and-drop, and typing mechanics
- add navigation buttons on HomeActivity and manifest entries
- log correct answers via StatisticsDataHelper and expose new strings for scoring feedback

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b496f6f8832990102391b3bee671