### PR TITLE
Refine study modes and integrate into quiz

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
         <activity android:name=".Profile.ProfileSettingsActivity" />
         <activity android:name=".Vocabulary.VocabularyDetailActivity" />
         <activity android:name=".Achivements.AchievementsActivity" />
+        <activity android:name=".Quiz.LearnModeActivity" />
+        <activity android:name=".Quiz.MatchModeActivity" />
+        <activity android:name=".Quiz.TestModeActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/learningenglishapplication/Data/DataHelper/VocabularyDataHelper.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Data/DataHelper/VocabularyDataHelper.java
@@ -307,6 +307,43 @@ public class VocabularyDataHelper {
     }
 
     /**
+     * Lấy danh sách từ vựng cho một người dùng.
+     * Nếu favoritesOnly = true thì chỉ lấy các từ được đánh dấu yêu thích.
+     */
+    public List<Vocabulary> getVocabulariesForUser(long userId, boolean favoritesOnly) {
+        List<Vocabulary> vocabularyList = new ArrayList<>();
+        SQLiteDatabase db = dbHelper.getReadableDatabase();
+        String selection = DatabaseHelper.COLUMN_VOCAB_USER_ID + "=?";
+        if (favoritesOnly) {
+            selection += " AND " + DatabaseHelper.COLUMN_VOCAB_IS_FAVORITE + "=1";
+        }
+        Cursor cursor = db.query(DatabaseHelper.TABLE_VOCABULARIES, null, selection,
+                new String[]{String.valueOf(userId)}, null, null, null);
+
+        if (cursor.moveToFirst()) {
+            do {
+                long id = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_ID));
+                String word = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_WORD));
+                String meaning = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_MEANING));
+                String pronunciation = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_PRONUNCIATION));
+                int isFavorite = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_IS_FAVORITE));
+                int learned = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_LEARNED));
+                String dateLearned = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_DATE_LEARNED));
+                String imageUri = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_IMAGE_URI));
+                String audioUri = cursor.getString(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_AUDIO_URI));
+                int box = cursor.getInt(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_BOX));
+                long nextReview = cursor.getLong(cursor.getColumnIndexOrThrow(DatabaseHelper.COLUMN_VOCAB_NEXT_REVIEW));
+
+                vocabularyList.add(new Vocabulary(id, word, meaning, pronunciation, isFavorite, learned, dateLearned,
+                        imageUri, audioUri, box, nextReview));
+            } while (cursor.moveToNext());
+        }
+        cursor.close();
+        db.close();
+        return vocabularyList;
+    }
+
+    /**
      * Tìm kiếm từ vựng theo từ khóa cho một người dùng.
      * Tìm trong cả cột 'word' và 'meaning'.
      */

--- a/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
@@ -99,6 +99,7 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
             startActivity(intent);
         });
 
+
         // RecyclerView
         recyclerView = findViewById(R.id.rv_home_categories);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/java/com/example/learningenglishapplication/Quiz/LearnModeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Quiz/LearnModeActivity.java
@@ -1,0 +1,116 @@
+package com.example.learningenglishapplication.Quiz;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Multiple choice practice mode inside the Quiz module.
+ */
+public class LearnModeActivity extends AppCompatActivity implements View.OnClickListener {
+
+    private TextView tvQuestionCounter, tvScore, questionText;
+    private ProgressBar progressBar;
+    private Button option1, option2, option3, option4;
+    private List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int currentIndex = 0;
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_learn);
+
+        tvQuestionCounter = findViewById(R.id.tv_question_counter);
+        tvScore = findViewById(R.id.tv_score);
+        questionText = findViewById(R.id.question_text);
+        progressBar = findViewById(R.id.pb_progress);
+        option1 = findViewById(R.id.option1);
+        option2 = findViewById(R.id.option2);
+        option3 = findViewById(R.id.option3);
+        option4 = findViewById(R.id.option4);
+
+        option1.setOnClickListener(this);
+        option2.setOnClickListener(this);
+        option3.setOnClickListener(this);
+        option4.setOnClickListener(this);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        // Receive questions from QuizSetupActivity
+        List<Vocabulary> questions = (List<Vocabulary>) getIntent().getSerializableExtra("QUIZ_QUESTIONS");
+        if (questions != null) {
+            vocabularyList.addAll(questions);
+        }
+        Collections.shuffle(vocabularyList);
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        loadNextQuestion();
+    }
+
+    private void loadNextQuestion() {
+        if (currentIndex >= vocabularyList.size()) {
+            showResult();
+            return;
+        }
+        Vocabulary current = vocabularyList.get(currentIndex);
+        questionText.setText(current.getWord());
+
+        List<String> options = new ArrayList<>();
+        options.add(current.getMeaning());
+        for (int i = 1; i < 4 && i < vocabularyList.size(); i++) {
+            Vocabulary v = vocabularyList.get((currentIndex + i) % vocabularyList.size());
+            options.add(v.getMeaning());
+        }
+        while (options.size() < 4) {
+            options.add("?");
+        }
+        Collections.shuffle(options);
+        option1.setText(options.get(0));
+        option2.setText(options.get(1));
+        option3.setText(options.get(2));
+        option4.setText(options.get(3));
+        tvQuestionCounter.setText(getString(R.string.question_counter_format, currentIndex + 1, vocabularyList.size()));
+        tvScore.setText(getString(R.string.score_format, score, vocabularyList.size()));
+        progressBar.setProgress((currentIndex * 100) / vocabularyList.size());
+    }
+
+    @Override
+    public void onClick(View v) {
+        Button b = (Button) v;
+        String selected = b.getText().toString();
+        Vocabulary current = vocabularyList.get(currentIndex);
+        if (selected.equals(current.getMeaning())) {
+            score++;
+            statisticsDataHelper.logWordLearned(userId);
+            Toast.makeText(this, R.string.correct, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, R.string.incorrect, Toast.LENGTH_SHORT).show();
+        }
+        currentIndex++;
+        loadNextQuestion();
+    }
+
+    private void showResult() {
+        tvScore.setText(getString(R.string.final_score_format, score, vocabularyList.size()));
+        progressBar.setProgress(100);
+    }
+}

--- a/app/src/main/java/com/example/learningenglishapplication/Quiz/MatchModeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Quiz/MatchModeActivity.java
@@ -1,0 +1,115 @@
+package com.example.learningenglishapplication.Quiz;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.DragEvent;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Drag and drop matching mode inside the Quiz module.
+ */
+public class MatchModeActivity extends AppCompatActivity {
+
+    private LinearLayout wordContainer, meaningContainer;
+    private TextView scoreText;
+    private final List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_match);
+
+        wordContainer = findViewById(R.id.word_container);
+        meaningContainer = findViewById(R.id.meaning_container);
+        scoreText = findViewById(R.id.score_text);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        List<Vocabulary> questions = (List<Vocabulary>) getIntent().getSerializableExtra("QUIZ_QUESTIONS");
+        if (questions != null) {
+            vocabularyList.addAll(questions);
+        }
+        Collections.shuffle(vocabularyList);
+        if (vocabularyList.size() > 5) {
+            vocabularyList.subList(5, vocabularyList.size()).clear();
+        }
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        setupViews();
+        updateScore();
+    }
+
+    private void setupViews() {
+        for (Vocabulary v : vocabularyList) {
+            TextView wordView = createTextView(v.getWord());
+            wordView.setTag(v.getMeaning());
+            wordView.setOnLongClickListener(view -> {
+                View.DragShadowBuilder shadow = new View.DragShadowBuilder(view);
+                view.startDragAndDrop(null, shadow, view, 0);
+                return true;
+            });
+            wordContainer.addView(wordView);
+        }
+
+        List<Vocabulary> shuffled = new ArrayList<>(vocabularyList);
+        Collections.shuffle(shuffled);
+        for (Vocabulary v : shuffled) {
+            TextView meaningView = createTextView(v.getMeaning());
+            meaningView.setTag(v.getMeaning());
+            meaningView.setOnDragListener((view, event) -> handleDrag(view, event));
+            meaningContainer.addView(meaningView);
+        }
+    }
+
+    private TextView createTextView(String text) {
+        TextView tv = new TextView(this);
+        tv.setText(text);
+        tv.setPadding(16, 16, 16, 16);
+        tv.setBackgroundResource(R.drawable.item_background);
+        tv.setTextColor(getResources().getColor(android.R.color.black));
+        return tv;
+    }
+
+    private boolean handleDrag(View view, DragEvent event) {
+        if (event.getAction() == DragEvent.ACTION_DROP) {
+            View dragged = (View) event.getLocalState();
+            String from = (String) dragged.getTag();
+            String target = (String) view.getTag();
+            if (from.equals(target)) {
+                dragged.setVisibility(View.INVISIBLE);
+                view.setBackgroundColor(0xFFB2FF59); // Green highlight
+                score++;
+                statisticsDataHelper.logWordLearned(userId);
+                updateScore();
+                if (score == vocabularyList.size()) {
+                    Toast.makeText(this, getString(R.string.final_score_format, score, vocabularyList.size()), Toast.LENGTH_LONG).show();
+                }
+            } else {
+                Toast.makeText(this, R.string.incorrect, Toast.LENGTH_SHORT).show();
+            }
+        }
+        return true;
+    }
+
+    private void updateScore() {
+        scoreText.setText(getString(R.string.score_format, score, vocabularyList.size()));
+    }
+}

--- a/app/src/main/java/com/example/learningenglishapplication/Quiz/QuizSetupActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Quiz/QuizSetupActivity.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.Toast;
 
@@ -16,6 +17,9 @@ import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelp
 import com.example.learningenglishapplication.Data.DatabaseHelper;
 import com.example.learningenglishapplication.Data.model.Vocabulary;
 import com.example.learningenglishapplication.R;
+import com.example.learningenglishapplication.Quiz.LearnModeActivity;
+import com.example.learningenglishapplication.Quiz.MatchModeActivity;
+import com.example.learningenglishapplication.Quiz.TestModeActivity;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,6 +32,7 @@ public class QuizSetupActivity extends AppCompatActivity {
     private Spinner spinnerCategory;
     private EditText etNumberOfQuestions;
     private Button btnStartQuiz;
+    private RadioGroup rgQuizType;
     private DatabaseHelper databaseHelper;
     private VocabularyDataHelper vocabularyDataHelper; // Sửa tên lớp
     private CategoryDataHelper categoryDataHelper; // Sửa tên lớp
@@ -52,6 +57,7 @@ public class QuizSetupActivity extends AppCompatActivity {
         spinnerCategory = findViewById(R.id.spinner_quiz_category);
         etNumberOfQuestions = findViewById(R.id.et_number_of_questions);
         btnStartQuiz = findViewById(R.id.btn_start_quiz);
+        rgQuizType = findViewById(R.id.rg_quiz_type);
 
         loadCategoriesIntoSpinner();
 
@@ -113,9 +119,23 @@ public class QuizSetupActivity extends AppCompatActivity {
         Collections.shuffle(allVocabs);
         List<Vocabulary> quizQuestions = new ArrayList<>(allVocabs.subList(0, numberOfQuestions));
 
-        Intent intent = new Intent(this, QuizActivity.class);
+        Class<?> target;
+        int selectedType = rgQuizType.getCheckedRadioButtonId();
+        if (selectedType == R.id.rb_learn) {
+            target = LearnModeActivity.class;
+        } else if (selectedType == R.id.rb_match) {
+            target = MatchModeActivity.class;
+        } else if (selectedType == R.id.rb_test) {
+            target = TestModeActivity.class;
+        } else {
+            target = QuizActivity.class;
+        }
+
+        Intent intent = new Intent(this, target);
         intent.putExtra("QUIZ_QUESTIONS", (Serializable) quizQuestions);
-        intent.putExtra("ALL_VOCABS", (Serializable) allVocabs);
+        if (target == QuizActivity.class) {
+            intent.putExtra("ALL_VOCABS", (Serializable) allVocabs);
+        }
         startActivity(intent);
     }
 }

--- a/app/src/main/java/com/example/learningenglishapplication/Quiz/TestModeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Quiz/TestModeActivity.java
@@ -1,0 +1,95 @@
+package com.example.learningenglishapplication.Quiz;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.learningenglishapplication.Data.DataHelper.StatisticsDataHelper;
+import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.example.learningenglishapplication.R;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Typing test mode inside the Quiz module.
+ */
+public class TestModeActivity extends AppCompatActivity {
+
+    private TextView tvQuestionCounter, tvScore, questionText;
+    private EditText answerInput;
+    private Button submitButton;
+    private ProgressBar progressBar;
+    private final List<Vocabulary> vocabularyList = new ArrayList<>();
+    private int currentIndex = 0;
+    private int score = 0;
+    private long userId;
+    private StatisticsDataHelper statisticsDataHelper;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test);
+
+        tvQuestionCounter = findViewById(R.id.tv_question_counter);
+        tvScore = findViewById(R.id.tv_score);
+        questionText = findViewById(R.id.question_text);
+        answerInput = findViewById(R.id.answer_input);
+        submitButton = findViewById(R.id.submit_button);
+        progressBar = findViewById(R.id.pb_progress);
+
+        SharedPreferences prefs = getSharedPreferences("user_prefs", MODE_PRIVATE);
+        userId = prefs.getLong("userId", -1);
+
+        List<Vocabulary> questions = (List<Vocabulary>) getIntent().getSerializableExtra("QUIZ_QUESTIONS");
+        if (questions != null) {
+            vocabularyList.addAll(questions);
+        }
+        Collections.shuffle(vocabularyList);
+
+        statisticsDataHelper = new StatisticsDataHelper(this);
+
+        submitButton.setOnClickListener(v -> checkAnswer());
+        loadNextQuestion();
+    }
+
+    private void loadNextQuestion() {
+        if (currentIndex >= vocabularyList.size()) {
+            showResult();
+            return;
+        }
+        Vocabulary current = vocabularyList.get(currentIndex);
+        questionText.setText(current.getMeaning());
+        answerInput.setText("");
+        tvQuestionCounter.setText(getString(R.string.question_counter_format, currentIndex + 1, vocabularyList.size()));
+        tvScore.setText(getString(R.string.score_format, score, vocabularyList.size()));
+        progressBar.setProgress((currentIndex * 100) / vocabularyList.size());
+    }
+
+    private void checkAnswer() {
+        Vocabulary current = vocabularyList.get(currentIndex);
+        String answer = answerInput.getText().toString().trim();
+        if (answer.equalsIgnoreCase(current.getWord())) {
+            score++;
+            statisticsDataHelper.logWordLearned(userId);
+            Toast.makeText(this, R.string.correct, Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(this, getString(R.string.correct_answer, current.getWord()), Toast.LENGTH_SHORT).show();
+        }
+        currentIndex++;
+        loadNextQuestion();
+    }
+
+    private void showResult() {
+        submitButton.setEnabled(false);
+        tvScore.setText(getString(R.string.final_score_format, score, vocabularyList.size()));
+        progressBar.setProgress(100);
+    }
+}

--- a/app/src/main/res/layout/activity_learn.xml
+++ b/app/src/main/res/layout/activity_learn.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/spacing_medium"
+    android:background="@color/background_color">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:id="@+id/tv_question_counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/text_color_primary" />
+        <ProgressBar
+            android:id="@+id/pb_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:max="100"
+            android:layout_marginStart="@dimen/spacing_medium"
+            android:layout_marginEnd="@dimen/spacing_medium" />
+        <TextView
+            android:id="@+id/tv_score"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="@color/text_color_primary" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="180dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
+        android:background="@drawable/item_background"
+        android:gravity="center"
+        android:padding="@dimen/spacing_medium">
+        <TextView
+            android:id="@+id/question_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_color_primary" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:layout_marginTop="@dimen/spacing_large">
+
+        <Button
+            android:id="@+id/option1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_small" />
+
+        <Button
+            android:id="@+id/option2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_small" />
+
+        <Button
+            android:id="@+id/option3"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_small" />
+
+        <Button
+            android:id="@+id/option4"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_match.xml
+++ b/app/src/main/res/layout/activity_match.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/spacing_medium"
+    android:background="@color/background_color">
+
+    <TextView
+        android:id="@+id/score_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="@color/text_color_primary"
+        android:layout_marginBottom="@dimen/spacing_medium" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginTop="@dimen/spacing_small">
+
+        <LinearLayout
+            android:id="@+id/word_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:background="@drawable/item_background"
+            android:padding="@dimen/spacing_small" />
+
+        <LinearLayout
+            android:id="@+id/meaning_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:background="@drawable/item_background"
+            android:padding="@dimen/spacing_small" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_setup.xml
+++ b/app/src/main/res/layout/activity_quiz_setup.xml
@@ -68,8 +68,27 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:layout_marginTop="@dimen/spacing_small">
-            <RadioButton android:id="@+id/rb_multiple_choice" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Trắc nghiệm (chọn nghĩa)" android:checked="true"/>
-            <RadioButton android:id="@+id/rb_fill_in_blank" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Điền từ (chọn từ)"/>
+            <RadioButton
+                android:id="@+id/rb_quiz"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Kiểm tra (trắc nghiệm)"
+                android:checked="true" />
+            <RadioButton
+                android:id="@+id/rb_learn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Học (trắc nghiệm)" />
+            <RadioButton
+                android:id="@+id/rb_match"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Ghép nghĩa" />
+            <RadioButton
+                android:id="@+id/rb_test"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Điền từ" />
         </RadioGroup>
 
         <View

--- a/app/src/main/res/layout/activity_test.xml
+++ b/app/src/main/res/layout/activity_test.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/spacing_medium"
+    android:background="@color/background_color">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:id="@+id/tv_question_counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="@color/text_color_primary" />
+        <ProgressBar
+            android:id="@+id/pb_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:max="100"
+            android:layout_marginStart="@dimen/spacing_medium"
+            android:layout_marginEnd="@dimen/spacing_medium" />
+        <TextView
+            android:id="@+id/tv_score"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="@color/text_color_primary" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="180dp"
+        android:layout_marginTop="@dimen/spacing_extra_large"
+        android:background="@drawable/item_background"
+        android:gravity="center"
+        android:padding="@dimen/spacing_medium">
+        <TextView
+            android:id="@+id/question_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_color_primary" />
+    </LinearLayout>
+
+    <EditText
+        android:id="@+id/answer_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_large"
+        android:hint="Type answer" />
+
+    <Button
+        android:id="@+id/submit_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Submit"
+        android:layout_marginTop="@dimen/spacing_medium" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,11 @@
     <string name="category_progress_label">%1$d/%2$d từ</string>
     <string name="category_progress_percent">%1$d%%</string>
 
+    <string name="score_format">Score: %1$d/%2$d</string>
+    <string name="final_score_format">Completed! Score: %1$d/%2$d</string>
+    <string name="correct">Correct!</string>
+    <string name="incorrect">Incorrect!</string>
+    <string name="correct_answer">Correct answer: %1$s</string>
+    <string name="question_counter_format">Question %1$d/%2$d</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- integrate Learn, Match, and Test modes into the quiz module with progress tracking
- allow selecting study mode in QuizSetupActivity
- polish study layouts for a consistent look

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1b496f6f8832990102391b3bee671