### PR TITLE
feat(ui): modernize key screens with material design

### DIFF
--- a/app/src/main/java/com/example/learningenglishapplication/Auth/LoginActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Auth/LoginActivity.java
@@ -4,9 +4,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -20,8 +20,8 @@ import com.example.learningenglishapplication.R;
 
 public class LoginActivity extends AppCompatActivity {
 
-    private EditText etEmail, etPassword;
-    private Button btnLogin;
+    private TextInputEditText etEmail, etPassword;
+    private MaterialButton btnLogin;
     private TextView tvGoToRegister;
     private UserDataHelper userHelper;
     private UserSettingDataHelper userSettingHelper;
@@ -30,6 +30,9 @@ public class LoginActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
+
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_login);
+        setSupportActionBar(toolbar);
 
         userHelper = new UserDataHelper(this);
         userSettingHelper = new UserSettingDataHelper(this);

--- a/app/src/main/java/com/example/learningenglishapplication/Auth/RegisterActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Auth/RegisterActivity.java
@@ -3,9 +3,9 @@ package com.example.learningenglishapplication.Auth;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -16,8 +16,8 @@ import com.example.learningenglishapplication.R;
 
 public class RegisterActivity extends AppCompatActivity {
 
-    private EditText etEmail, etPassword, etConfirmPassword, etNickname;
-    private Button btnRegister;
+    private TextInputEditText etEmail, etPassword, etConfirmPassword, etNickname;
+    private MaterialButton btnRegister;
     private TextView tvGoToLogin;
     private UserDataHelper userHelper;
 
@@ -25,6 +25,13 @@ public class RegisterActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register);
+
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_register);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+        toolbar.setNavigationOnClickListener(v -> finish());
 
         userHelper = new UserDataHelper(this);
 
@@ -36,20 +43,10 @@ public class RegisterActivity extends AppCompatActivity {
         btnRegister = findViewById(R.id.btn_register);
         tvGoToLogin = findViewById(R.id.tv_go_to_login);
 
-        btnRegister.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                registerUser();
-            }
-        });
+        btnRegister.setOnClickListener(v -> registerUser());
 
-        tvGoToLogin.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // Chuyển sang màn hình Đăng nhập
-                startActivity(new Intent(RegisterActivity.this, LoginActivity.class));
-            }
-        });
+        tvGoToLogin.setOnClickListener(v ->
+                startActivity(new Intent(RegisterActivity.this, LoginActivity.class)));
     }
 
     private void registerUser() {

--- a/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Home/HomeActivity.java
@@ -20,6 +20,7 @@ import com.example.learningenglishapplication.R;
 import com.example.learningenglishapplication.Vocabulary.VocabularyListActivity;
 import com.example.learningenglishapplication.category.CategoryAdapter;
 import com.example.learningenglishapplication.category.CategoryManagementActivity;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.navigation.NavigationBarView;
 
 import java.util.Random;
@@ -36,6 +37,7 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
     private TextView quoteTextView;
     private TextView tvLoiChao, tvTenNguoiDung;
     private ImageView ivAvatar;
+    private MaterialToolbar topAppBar;
 
     private final String[][] quotes = {
             {"Achieve", "Đạt được"},
@@ -66,6 +68,8 @@ public class HomeActivity extends AppCompatActivity implements CategoryAdapter.O
         setContentView(R.layout.activity_home);
 
         // Ánh xạ view
+        topAppBar = findViewById(R.id.top_app_bar);
+        setSupportActionBar(topAppBar);
         tvLoiChao = findViewById(R.id.tv_loi_chao);
         tvTenNguoiDung = findViewById(R.id.tv_ten_nguoi_dung);
         ivAvatar = findViewById(R.id.nut_ho_so);

--- a/app/src/main/java/com/example/learningenglishapplication/Profile/ProfileSettingsActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Profile/ProfileSettingsActivity.java
@@ -6,9 +6,10 @@ import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import com.google.android.material.appbar.MaterialToolbar;
+import com.google.android.material.button.MaterialButton;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -34,12 +35,19 @@ public class ProfileSettingsActivity extends AppCompatActivity {
 
     private LinearLayout layoutTheme;
     private TextView tvCurrentTheme;
-    private Button btnLogout;
+    private MaterialButton btnLogout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile_settings);
+
+        MaterialToolbar toolbar = findViewById(R.id.toolbar_profile);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+        toolbar.setNavigationOnClickListener(v -> finish());
 
         // Khởi tạo helper
         userSettingDataHelper = new UserSettingDataHelper(this);

--- a/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyListActivity.java
+++ b/app/src/main/java/com/example/learningenglishapplication/Vocabulary/VocabularyListActivity.java
@@ -11,7 +11,6 @@ import android.os.Handler;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
@@ -34,6 +33,7 @@ import com.example.learningenglishapplication.Data.DatabaseHelper;
 import com.example.learningenglishapplication.Data.DataHelper.VocabularyDataHelper;
 import com.example.learningenglishapplication.R;
 import com.example.learningenglishapplication.Data.model.Vocabulary;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 public class VocabularyListActivity extends AppCompatActivity implements VocabularyAdapter.OnItemInteractionListener, VocabularyAdapter.OnFavoriteClickListener {
@@ -43,7 +43,7 @@ public class VocabularyListActivity extends AppCompatActivity implements Vocabul
     private DatabaseHelper databaseHelper;
     private VocabularyDataHelper vocabularyHelper;
     private FloatingActionButton fabAddVocabulary;
-    private Button btnStartFlashcard;
+    private MaterialButton btnStartFlashcard;
     private TextView tvEmptyMessage;
     private ImageView btnFilter;
     private TextView tvVocabularyCount;

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -4,12 +4,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#EDE9FE"
     tools:context=".Home.HomeActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:title="@string/app_name"
+        android:titleTextColor="?attr/colorOnPrimary" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_below="@id/top_app_bar"
         android:layout_above="@id/bottom_navigation"
         android:fillViewport="true">
 
@@ -19,53 +27,58 @@
             android:orientation="vertical"
             android:padding="@dimen/spacing_medium">
 
-            <!-- Search + Avatar -->
-            <!-- Lời chào + Avatar -->
-            <LinearLayout
+            <!-- Greeting card -->
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Learning.Card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:padding="@dimen/spacing_medium"
-                android:gravity="center_vertical"
-                android:background="@drawable/bg_nen_mau_xanh">
+                android:layout_marginBottom="@dimen/spacing_medium">
 
                 <LinearLayout
-                    android:layout_width="0dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
+                    android:orientation="horizontal"
+                    android:padding="@dimen/spacing_medium"
+                    android:gravity="center_vertical">
 
-                    <TextView
-                        android:id="@+id/tv_loi_chao"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="Chào mừng quay trở lại,"
-                        android:textColor="@android:color/black"
-                        android:textSize="16sp"
-                        android:textStyle="bold" />
+                        android:layout_weight="1"
+                        android:orientation="vertical">
 
-                    <TextView
-                        android:id="@+id/tv_ten_nguoi_dung"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Biệt danh"
-                        android:textColor="@android:color/black"
-                        android:textSize="20sp"
-                        android:textStyle="bold" />
+                        <TextView
+                            android:id="@+id/tv_loi_chao"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Chào mừng quay trở lại,"
+                            android:textColor="@android:color/black"
+                            android:textSize="16sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/tv_ten_nguoi_dung"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Biệt danh"
+                            android:textColor="@android:color/black"
+                            android:textSize="20sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <com.google.android.material.imageview.ShapeableImageView
+                        android:id="@+id/nut_ho_so"
+                        android:layout_width="56dp"
+                        android:layout_height="56dp"
+                        android:src="@drawable/avatar"
+                        android:scaleType="centerCrop"
+                        android:contentDescription="Hồ sơ"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        app:shapeAppearanceOverlay="@style/AvatarShape" />
                 </LinearLayout>
-
-                <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/nut_ho_so"
-                    android:layout_width="56dp"
-                    android:layout_height="56dp"
-                    android:src="@drawable/avatar"
-                    android:scaleType="centerCrop"
-                    android:contentDescription="Hồ sơ"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:background="?attr/selectableItemBackgroundBorderless"
-                    app:shapeAppearanceOverlay="@style/AvatarShape" />
-            </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Chuỗi ngày học -->
             <TextView
@@ -98,20 +111,25 @@
                 tools:ignore="SpeakableTextPresentCheck" />
 
             <!-- Quote thay thế CalendarView -->
-            <TextView
-                android:id="@+id/quote_text"
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Learning.Card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Hãy cùng xem 1 vài từ mới ngày hôm nay nào  !"
-                android:textColor="@android:color/black"
-                android:textStyle="italic"
-                android:textSize="18sp"
-                android:background="@drawable/bg_nen_mau_xanh"
-                android:padding="@dimen/spacing_medium"
-                android:gravity="center"
-                android:layout_marginBottom="@dimen/spacing_medium"
-                android:clickable="true"
-                android:focusable="true" />
+                android:layout_marginBottom="@dimen/spacing_medium">
+
+                <TextView
+                    android:id="@+id/quote_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Hãy cùng xem 1 vài từ mới ngày hôm nay nào  !"
+                    android:textColor="@android:color/black"
+                    android:textStyle="italic"
+                    android:textSize="18sp"
+                    android:padding="@dimen/spacing_medium"
+                    android:gravity="center"
+                    android:clickable="true"
+                    android:focusable="true" />
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Học phần -->
             <TextView

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,99 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:gravity="center"
-    android:padding="@dimen/spacing_large"
     android:background="@color/background_color"
     tools:context=".Auth.LoginActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Chào mừng trở lại!"
-        android:textSize="28sp"
-        android:textStyle="bold"
-        android:textColor="?attr/colorPrimary"/>
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_login"
+        style="@style/Widget.Learning.Toolbar"
+        app:title="Đăng Nhập" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Đăng nhập để tiếp tục"
-        android:textSize="16sp"
-        android:layout_marginTop="@dimen/spacing_small"
-        android:textColor="@color/text_color_secondary"/>
-
-    <!-- Form đăng nhập -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_marginTop="48dp">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Email"
-            android:textColor="@color/text_color_primary"/>
-
-        <EditText
-            android:id="@+id/et_login_email"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:hint="nhapemail@gmail.com"
-            android:inputType="textEmailAddress"
-            android:background="@drawable/item_background"
-            android:padding="12dp"/>
+        android:padding="@dimen/spacing_large">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Mật khẩu"
-            android:layout_marginTop="@dimen/spacing_medium"
-            android:textColor="@color/text_color_primary"/>
-
-        <EditText
-            android:id="@+id/et_login_password"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:hint="Nhập mật khẩu của bạn"
-            android:inputType="textPassword"
-            android:background="@drawable/item_background"
-            android:padding="12dp"/>
-    </LinearLayout>
-
-    <Button
-        android:id="@+id/btn_login"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/spacing_extra_large"
-        android:text="Đăng Nhập"
-        android:padding="12dp"
-        android:backgroundTint="?attr/colorPrimary"
-        android:textColor="@color/white"/>
-
-    <!-- Link sang màn hình đăng ký -->
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginTop="@dimen/spacing_large">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Chưa có tài khoản? "
-            android:textColor="@color/text_color_secondary"/>
-
-        <TextView
-            android:id="@+id/tv_go_to_register"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Đăng ký ngay"
+            android:text="Chào mừng trở lại!"
+            android:textSize="28sp"
             android:textStyle="bold"
-            android:textColor="?attr/colorSecondary"/>
+            android:textColor="?attr/colorPrimary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Đăng nhập để tiếp tục"
+            android:textSize="16sp"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:textColor="@color/text_color_secondary" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Learning.TextField"
+            android:layout_marginTop="@dimen/spacing_extra_large">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_login_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="nhapemail@gmail.com"
+                android:inputType="textEmailAddress" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/Widget.Learning.TextField"
+            android:layout_marginTop="@dimen/spacing_medium">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_login_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Nhập mật khẩu của bạn"
+                android:inputType="textPassword" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_login"
+            style="@style/Widget.Learning.Button"
+            android:layout_marginTop="@dimen/spacing_extra_large"
+            android:text="Đăng Nhập" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="@dimen/spacing_large"
+            android:gravity="center">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Chưa có tài khoản? "
+                android:textColor="@color/text_color_secondary" />
+
+            <TextView
+                android:id="@+id/tv_go_to_register"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Đăng ký ngay"
+                android:textStyle="bold"
+                android:textColor="?attr/colorSecondary" />
+        </LinearLayout>
     </LinearLayout>
+
 </LinearLayout>
+

--- a/app/src/main/res/layout/activity_profile_settings.xml
+++ b/app/src/main/res/layout/activity_profile_settings.xml
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/layout_theme_setting"
     android:orientation="vertical"
     android:background="@color/background_color"
     tools:context=".Profile.ProfileSettingsActivity">
 
-    <!-- Thanh tiêu đề -->
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Cá Nhân"
-        android:padding="@dimen/spacing_medium"
-        android:background="?attr/colorPrimary"
-        android:textColor="@color/white"
-        android:textSize="20sp"
-        android:textStyle="bold"
-        android:gravity="center"/>
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_profile"
+        style="@style/Widget.Learning.Toolbar"
+        app:title="Cá Nhân"
+        app:navigationIcon="@drawable/ic_arrow_back" />
 
     <ScrollView
         android:layout_width="match_parent"
@@ -36,7 +30,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Tiến độ học tập"
-                android:textColor="@color/text_color_primary"/>
+                android:textColor="@color/text_color_primary" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -44,20 +39,20 @@
                 android:background="@drawable/item_background"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:padding="@dimen/spacing_medium">
+
                 <TextView
                     android:id="@+id/tv_stats_summary"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textSize="16sp"
-                    tools:text="Đã học 150 từ trong 15 thể loại."/>
-                <!-- Chỗ này để đặt biểu đồ, bạn sẽ cần một thư viện như MPAndroidChart -->
+                    tools:text="Đã học 150 từ trong 15 thể loại." />
+
                 <com.github.mikephil.charting.charts.BarChart
                     android:id="@+id/bar_chart_stats"
                     android:layout_width="match_parent"
                     android:layout_height="200dp"
-                    android:layout_marginTop="@dimen/spacing_medium"/>
+                    android:layout_marginTop="@dimen/spacing_medium" />
             </LinearLayout>
-
 
             <!-- Cài đặt học tập -->
             <TextView
@@ -66,47 +61,51 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_large"
                 android:text="Cài đặt học tập"
-                android:textColor="@color/text_color_primary"/>
+                android:textColor="@color/text_color_primary" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
+
                 <TextView
                     android:layout_width="0dp"
                     android:layout_weight="1"
                     android:layout_height="wrap_content"
                     android:text="Mục tiêu hàng ngày"
-                    android:textSize="16sp"/>
+                    android:textSize="16sp" />
+
                 <TextView
                     android:id="@+id/tv_daily_goal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="10 từ"
                     android:textStyle="bold"
-                    android:textSize="16sp"/>
+                    android:textSize="16sp" />
             </LinearLayout>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
+
                 <TextView
                     android:layout_width="0dp"
                     android:layout_weight="1"
                     android:layout_height="wrap_content"
                     android:text="Nhắc nhở hàng ngày"
-                    android:textSize="16sp"/>
-                <Switch
+                    android:textSize="16sp" />
+
+                <com.google.android.material.materialswitch.MaterialSwitch
                     android:id="@+id/switch_notifications"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:checked="true"
-                    tools:ignore="UseSwitchCompatOrMaterialXml" />
+                    android:checked="true" />
             </LinearLayout>
-
 
             <!-- Cài đặt ứng dụng -->
             <TextView
@@ -115,38 +114,41 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_large"
                 android:text="Cài đặt ứng dụng"
-                android:textColor="@color/text_color_primary"/>
+                android:textColor="@color/text_color_primary" />
+
             <LinearLayout
+                android:id="@+id/layout_theme_setting"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:gravity="center_vertical">
+
                 <TextView
                     android:layout_width="0dp"
                     android:layout_weight="1"
                     android:layout_height="wrap_content"
                     android:text="Giao diện (Theme)"
-                    android:textSize="16sp"/>
+                    android:textSize="16sp" />
+
                 <TextView
                     android:id="@+id/tv_theme"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="Sáng"
                     android:textStyle="bold"
-                    android:textSize="16sp"/>
+                    android:textSize="16sp" />
             </LinearLayout>
 
             <!-- Tài khoản -->
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_logout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                style="@style/Widget.Learning.Button"
+                android:layout_marginTop="@dimen/spacing_extra_large"
                 android:text="Đăng xuất"
-                android:backgroundTint="@android:color/holo_red_light"
-                android:textColor="@color/white"
-                android:layout_marginTop="@dimen/spacing_extra_large"/>
-
+                app:backgroundTint="@android:color/holo_red_light"
+                android:textColor="@color/white" />
         </LinearLayout>
     </ScrollView>
 </LinearLayout>
+

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,140 +1,122 @@
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:gravity="center"
-    android:padding="@dimen/spacing_large"
     android:background="@color/background_color"
     tools:context=".Auth.RegisterActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Tạo tài khoản mới"
-        android:textSize="28sp"
-        android:textStyle="bold"
-        android:textColor="?attr/colorPrimary"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Bắt đầu hành trình học từ vựng của bạn"
-        android:textSize="16sp"
-        android:layout_marginTop="@dimen/spacing_small"
-        android:textColor="@color/text_color_secondary"/>
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_register"
+        style="@style/Widget.Learning.Toolbar"
+        app:title="Đăng Ký"
+        app:navigationIcon="@drawable/ic_arrow_back" />
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_marginTop="@dimen/spacing_extra_large">
+        android:layout_height="match_parent"
+        android:padding="@dimen/spacing_large">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- Email -->
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Email"
-                android:textColor="@color/text_color_primary"/>
-            <EditText
-                android:id="@+id/et_register_email"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:hint="nhapemail@gmail.com"
-                android:inputType="textEmailAddress"
-                android:background="@drawable/item_background"
-                android:padding="12dp"/>
+                android:text="Tạo tài khoản mới"
+                android:textSize="28sp"
+                android:textStyle="bold"
+                android:textColor="?attr/colorPrimary" />
 
-            <!-- Biệt danh -->
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Biệt danh"
-                android:layout_marginTop="@dimen/spacing_medium"
-                android:textColor="@color/text_color_primary"/>
-            <EditText
-                android:id="@+id/et_register_nickname"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:text="Bắt đầu hành trình học từ vựng của bạn"
+                android:textSize="16sp"
                 android:layout_marginTop="@dimen/spacing_small"
-                android:hint="Nhập biệt danh"
-                android:inputType="textPersonName"
-                android:background="@drawable/item_background"
-                android:padding="12dp"/>
+                android:textColor="@color/text_color_secondary" />
 
-            <!-- Mật khẩu -->
-            <TextView
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.Learning.TextField"
+                android:layout_marginTop="@dimen/spacing_extra_large">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_register_email"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="nhapemail@gmail.com"
+                    android:inputType="textEmailAddress" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.Learning.TextField"
+                android:layout_marginTop="@dimen/spacing_medium">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_register_nickname"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="Nhập biệt danh"
+                    android:inputType="textPersonName" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.Learning.TextField"
+                android:layout_marginTop="@dimen/spacing_medium">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_register_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="Tối thiểu 6 ký tự"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.Learning.TextField"
+                android:layout_marginTop="@dimen/spacing_medium">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_register_confirm_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="Nhập lại mật khẩu"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_register"
+                style="@style/Widget.Learning.Button"
+                android:layout_marginTop="@dimen/spacing_large"
+                android:text="Đăng Ký" />
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Mật khẩu"
-                android:layout_marginTop="@dimen/spacing_medium"
-                android:textColor="@color/text_color_primary"/>
-            <EditText
-                android:id="@+id/et_register_password"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:hint="Tối thiểu 6 ký tự"
-                android:inputType="textPassword"
-                android:background="@drawable/item_background"
-                android:padding="12dp"/>
+                android:orientation="horizontal"
+                android:layout_marginTop="@dimen/spacing_large"
+                android:gravity="center">
 
-            <!-- Xác nhận mật khẩu -->
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Xác nhận mật khẩu"
-                android:layout_marginTop="@dimen/spacing_medium"
-                android:textColor="@color/text_color_primary"/>
-            <EditText
-                android:id="@+id/et_register_confirm_password"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:hint="Nhập lại mật khẩu"
-                android:inputType="textPassword"
-                android:background="@drawable/item_background"
-                android:padding="12dp"/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Đã có tài khoản? "
+                    android:textColor="@color/text_color_secondary" />
 
+                <TextView
+                    android:id="@+id/tv_go_to_login"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Đăng nhập"
+                    android:textStyle="bold"
+                    android:textColor="?attr/colorSecondary" />
+            </LinearLayout>
         </LinearLayout>
     </ScrollView>
 
-    <Button
-        android:id="@+id/btn_register"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/spacing_large"
-        android:text="Đăng Ký"
-        android:padding="12dp"
-        android:backgroundTint="?attr/colorPrimary"
-        android:textColor="@color/white"/>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginTop="@dimen/spacing_large">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Đã có tài khoản? "
-            android:textColor="@color/text_color_secondary"/>
-
-        <TextView
-            android:id="@+id/tv_go_to_login"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Đăng nhập"
-            android:textStyle="bold"
-            android:textColor="?attr/colorSecondary"/>
-    </LinearLayout>
-
 </LinearLayout>
+

--- a/app/src/main/res/layout/activity_vocabulary_list.xml
+++ b/app/src/main/res/layout/activity_vocabulary_list.xml
@@ -10,10 +10,7 @@
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_vocabulary_list"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        app:titleTextColor="@color/white">
+        style="@style/Widget.Learning.Toolbar">
 
         <ImageView
             android:id="@+id/btn_filter"
@@ -38,14 +35,12 @@
         android:gravity="center_vertical"
         android:text="Tổng số: 0 từ" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_start_flashcard"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Widget.Learning.Button"
         android:layout_margin="@dimen/spacing_medium"
         android:text="Ôn Tập Flashcard"
-        android:backgroundTint="?attr/colorSecondary"
-        android:textColor="@color/white" />
+        app:backgroundTint="?attr/colorSecondary" />
 
     <TextView
         android:id="@+id/tv_empty_message"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,4 +33,31 @@
         <item name="cornerSize">50%</item> <!-- 50% làm ảnh tròn tuyệt đối -->
     </style>
 
+    <!-- Card style for consistent rounded corners and elevation -->
+    <style name="Widget.Learning.Card" parent="Widget.Material3.CardView.Elevated">
+        <item name="cardCornerRadius">12dp</item>
+        <item name="cardElevation">2dp</item>
+    </style>
+
+    <!-- Toolbar style for a consistent app bar across screens -->
+    <style name="Widget.Learning.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:background">?attr/colorPrimary</item>
+        <item name="titleTextColor">?attr/colorOnPrimary</item>
+        <item name="android:layout_height">?attr/actionBarSize</item>
+    </style>
+
+    <!-- Primary button style used in forms and actions -->
+    <style name="Widget.Learning.Button" parent="Widget.Material3.Button">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
+    </style>
+
+    <!-- Text field style for form inputs -->
+    <style name="Widget.Learning.TextField" parent="Widget.Material3.TextInputLayout.OutlinedBox">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- add shared toolbar, button, and text field styles for consistent Material look
- rebuild login, register, profile settings, and vocabulary list screens using Material components
- wire up new toolbars in corresponding activities for navigation support

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec4d77b48329b39a7b7337c2ac58